### PR TITLE
chore: create action for starting dev server

### DIFF
--- a/start-dev-server/action.yml
+++ b/start-dev-server/action.yml
@@ -1,0 +1,34 @@
+name: "Start dev server"
+description: "Start a dev server"
+
+inputs:
+  COMMAND:
+    default: "npm run start"
+    description: "Command to start the dev server"
+    required: false
+  LOCAL_URL:
+    default: "http://localhost:1337"
+    description: "The url to the dev server"
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - name: 🏁 Start a dev server
+      shell: bash
+      # Start a dev sever in the background and poll the local url
+      # every fifth second until the server is up and running.
+      # The server is then shutdown when Github shuts down the action/OS
+      run: |
+        ${{ inputs.COMMAND }} &
+        attempt_counter=0
+        max_attempts=10
+        until $(curl --output /dev/null --silent --head --fail "${{ inputs.LOCAL_URL }}"); do
+          if [ ${attempt_counter} -eq ${max_attempts} ];then
+            echo "Unable to start dev server"
+            exit 1
+          fi
+          attempt_counter=$(($attempt_counter+1))
+          printf '.'
+          sleep 5
+        done


### PR DESCRIPTION
This PR adds the possibility for re-using logic for starting and verifying that a server has started. It is possible to override the start command and also the url that it will be "hosted" on. 